### PR TITLE
Add GitHub Actions workflow for Gradle build and artifact upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: write
+      contents: read
+      actions: read
     env:
       BASE_PATH: ${{ github.workspace }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gradle-build:
+    name: Gradle build (Java 8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    env:
+      BASE_PATH: ${{ github.workspace }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: gradle
+
+      - name: Make gradlew executable (Linux runner)
+        run: chmod +x gradlew
+
+      - name: Build all targets
+        run: ./gradlew --no-daemon --stacktrace buildForgeAll
+
+      - name: Upload JAR artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: IVV-all
+          path: |
+            out/*.jar
+          if-no-files-found: error
+
+      - name: Upload 1.12.2 JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: IVV-1.12.2
+          path: |
+            out/*1.12.2*.jar
+          if-no-files-found: warn
+
+      - name: Upload 1.16.5 JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: IVV-1.16.5
+          path: |
+            out/*1.16.5*.jar
+          if-no-files-found: warn
+
+      - name: Create GitHub Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Immersive Vehicles Vanity ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            out/*.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Hello IVL masters,**

As you may know, some time ago I started experimenting with the beautiful world of *workflows* and *pipelines*.
I’ve since made a few for all my Trin packs - and for some obscure reason, today I felt like setting up a few more...
Unfortunately for you, this time **you’ve been my victim** 😈

So, I present to you a new GitHub Actions workflow that automatically builds IVV on every commit you push.

**Note:** I have a GitHub Pro account, but I’m not sure whether the GitHub servers will allow runners for your repository. Hopefully they will - otherwise, you can simply disable the workflow.